### PR TITLE
Remove protobuf cells

### DIFF
--- a/SageMaker-Seq2Seq-Translation-English-German-InternetFacingApp.ipynb
+++ b/SageMaker-Seq2Seq-Translation-English-German-InternetFacingApp.ipynb
@@ -39,20 +39,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "isConfigCell": true
    },
    "outputs": [],
    "source": [
     "# S3 bucket and prefix\n",
-    "bucket = '<your_s3_bucket_name_here>'\n",
-    "prefix = 'sagemaker/<your_s3_prefix_here>'  # E.g.'sagemaker/seq2seq/eng-german'"
+    "bucket = 'sagemaker-robpercaws-lab'\n",
+    "prefix = 'sagemaker/seq2seq/eng-german'  # E.g.'sagemaker/seq2seq/eng-german'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,9 +112,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using SageMaker Seq2Seq container: 811284229777.dkr.ecr.us-east-1.amazonaws.com/seq2seq:latest (us-east-1)\n"
+     ]
+    }
+   ],
    "source": [
     "containers = {'us-west-2': '433757028032.dkr.ecr.us-west-2.amazonaws.com/seq2seq:latest',\n",
     "              'us-east-1': '811284229777.dkr.ecr.us-east-1.amazonaws.com/seq2seq:latest',\n",
@@ -140,9 +148,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100  312M  100  312M    0     0  11.4M      0  0:00:27  0:00:27 --:--:-- 16.4M\n",
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100 1066k  100 1066k    0     0   304k      0  0:00:03  0:00:03 --:--:--  304k\n",
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100 1180k  100 1180k    0     0   306k      0  0:00:03  0:00:03 --:--:--  306k\n"
+     ]
+    }
+   ],
    "source": [
     "use_pretrained_model = True\n",
     "model_name = \"pretrained-en-de-model\"\n",
@@ -155,9 +179,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pretrained-en-de-model\n",
+      "s3://sagemaker-robpercaws-lab/sagemaker/seq2seq/eng-german/pretrained_model/model.tar.gz\n",
+      "arn:aws:sagemaker:us-east-1:426111819794:model/pretrained-en-de-model\n",
+      "CPU times: user 20 ms, sys: 0 ns, total: 20 ms\n",
+      "Wall time: 244 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "\n",
@@ -196,9 +232,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seq2SeqEndpointConfig-2018-05-21-03-27-14\n",
+      "Endpoint Config Arn: arn:aws:sagemaker:us-east-1:426111819794:endpoint-config/seq2seqendpointconfig-2018-05-21-03-27-14\n"
+     ]
+    }
+   ],
    "source": [
     "from time import gmtime, strftime\n",
     "\n",
@@ -225,9 +270,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seq2SeqEndpoint-2018-05-21-03-27-21\n",
+      "arn:aws:sagemaker:us-east-1:426111819794:endpoint/seq2seqendpoint-2018-05-21-03-27-21\n",
+      "Status: Creating\n",
+      "Endpoint creation ended with EndpointStatus = InService\n",
+      "CPU times: user 36 ms, sys: 12 ms, total: 48 ms\n",
+      "Wall time: 5min 31s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "import time\n",
@@ -269,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,9 +357,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'predictions': [{'target': 'Sie sind so gut !'}, {'target': 'können Sie ein Auto fahren ?'}, {'target': 'ich will einen Film besuchen .'}]}\n"
+     ]
+    }
+   ],
    "source": [
     "sentences = [\"you are so good !\",\n",
     "             \"can you drive a car ?\",\n",
@@ -337,9 +403,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source: can you drive a car ? \n",
+      "Target: können Sie ein Auto fahren ?\n"
+     ]
+    }
+   ],
    "source": [
     "sentence = 'can you drive a car ?'\n",
     "\n",
@@ -365,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,135 +461,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAASgAAAEYCAYAAADvfWu0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvNQv5yAAAE/pJREFUeJzt3X+UXGV9x/H3J2EhkeBGyDYmHELAKpiAYrNQYgQC4q+2VqmUgFJIK0ZKLdiiWAXbtRatgh4rHMVUsKEHNUGCRBEBMYkWjAqGBMIPU0NAAhWWXwLqhiTf/nGfJcM6k0x29859ZvN5nbMnd+69c+93ZieffZ5n7jyjiMDMLEejqi7AzKwRB5SZZcsBZWbZckCZWbYcUGaWLQeUmWXLAWVm2XJAmVm2HFBmlq1dqi6gLLvvvnuMHz++6jLqmjRpUtUlmFVm/fr19Pb2qpl9R2xAjR8/njPOOKPqMur6yEc+UnUJdUlNvWasTWzZsqXqEuo67LDDmt7XXTwzy5YDysyy5YAys2w5oMwsWw4oM8uWA8rMsuWAMrNsOaDMLFsOKDPLlgPKzLLlgDKzbDmgzCxbDigzy5YDysyy5YAys2w5oMwsW5UFlKRTJK2WtErSf0t6q6QfS1op6XuSJqb9eiRdJmmZpHWSzqyqZjNrrUpm1JQ0HTgXmBURvZL2BAI4PCJC0mnAOcDZ6S4HAkcDewD3SvpiRDxX57jzgHkAnZ2dLXgkZlamqqb8PQb4RkT0AkTE45IOBhZKmgTsCtxXs/+1EdEH9El6BJgIPDjwoBExH5gPsPfee0fJj8HMSlZVF08ULaZaFwEXR8TBwHuBMTXb+mqWNzOC51I3s62qCqibgBMk7QWQunidwIa0/dSK6jKzjFTSEomINZLOB5ZL2gysBHqAKyVtAFYA+1VRm5nlo7KuUkQsABYMWH1Nnf16Btw+qMSyzCwjvg7KzLLlgDKzbDmgzCxbDigzy5YDysyy5YAys2w5oMwsWw4oM8uWA8rMsuWAMrNsOaDMLFsOKDPLlgPKzLLlgDKzbI3YmSknTpzIWWedVXUZdc2ZM6fqEuq64oorqi6hoY6OjqpLaDuSqi5hyNyCMrNsOaDMLFsOKDPLlgPKzLLlgDKzbDmgzCxbDigzy5YDysyy5YAys2w5oMwsWw4oM8uWA8rMsuWAMrNsOaDMLFsOKDPLlgPKzLLlgDKzbFUSUJI+LumsmtvnSzpL0gWS7pR0h6Q5adtsSd+u2fdiSXMrKNvMWqyqFtSlwKkAkkYBJwIPAocArwaOBS6QNGlHDippnqRbJd3a29s7zCWbWatVElARsR54TNJrgDcCK4HXAV+LiM0R8StgOXDoDh53fkR0R0T3hAkThrtsM2uxKr804cvAXOClwGUUQVXPJl4YpGPKLcvMclHlIPnVwJspWknXAz8A5kgaLakLOBL4CXA/ME3SbpI6gddXVbCZtVZlLaiI2ChpKfBkRGyWdDUwE1gFBHBORPwfgKRFwGpgLUV30Mx2ApUFVBocPxz4S4CICOCD6ecFIuIc4JyWFmhmlavqMoNpwP8CN0XE2ipqMLP8VdKCioi7gP2rOLeZtQ9fSW5m2XJAmVm2HFBmli0HlJllywFlZtlyQJlZthxQZpYtB5SZZcsBZWbZckCZWbYcUGaWrSonrCtVX18f69atq7qMui6//PKqS6irr6+v6hIa6ujoqLqEhiZPnlx1CXU9+OCDVZcwZG5BmVm2HFBmli0HlJllywFlZtlyQJlZthxQZpYtB5SZZcsBZWbZckCZWbYcUGaWLQeUmWXLAWVm2XJAmVm2HFBmli0HlJllq2UBJalH0gfqrD9d0imtqsPM2kelE9ZJ2iUiLqmyBjPLV6kBJelc4BTgl8CjwG2SlgG3ALOAJZL2AJ4BrgUWRMRh6b5TgSUR8SpJM4DPAuOAXmBuRDxcZu1mVr3SungpVE4EXgP8BXBozebxEXFURHymf0VE3A3sKmn/tGoOsEhSB3ARcHxEzAAuA84vq24zy0eZLagjgKsj4jcAkpbUbFvY4D6LgBOAf6cIqDnAAcBBwI2SAEYDdVtPkuYB8wAmTZo09EdgZpUqewwqGqx/tsH6hcCVkhYDERFrJR0MrImImds9WcR8YD7A9OnTG53bzNpEme/i/QA4TtLYNM701u3dISJ+AWwGPsrWVta9QJekmQCSOiRNL6lmM8tIaS2oiPiZpIXA7cD9wA+bvOtC4AJgv3ScjZKOBz4vqZOi5s8Ba4a/ajPLSaldvIg4n98f0L5wwD49A25fWGef24EjSyjRzDLWVBdP0kRJl0q6Lt2eJund5ZZmZju7Zseg/gu4Huj/CtWfA+8voyAzs37NBtSEiFgEbAGIiE0Ug9lmZqVpNqCelbQX6bIBSYcDT5VWlZkZzQ+S/yOwBHiZpJuBLuD40qoyM6PJgEqXDBxFcVW3gHsj4rlSKzOznV6z7+L9HTAuItZExJ3AOElnlFuame3smh2Dek9EPNl/IyKeAN5TTklmZoVmA2qU0id1ASSNBnYtpyQzs0Kzg+Q3UEx9cgnFO3mnA98trSozM5oPqHMopjH5W4pB8huAL5dVlJkZNBFQqTu3ICJOBjw9r5m1zHbHoCJiM8V0Jx5zMrOWaraLtx64Oc2K+fxkcxHx2TKKMjOD5gPqofQzCtijvHKGz9ixY5k+Pc957Z5++umqS6jrxBNPrLqEhq677rqqS2jogQceqLqEumreeG9bzV5J/rGyCzEzG6ipgJK0lDrzi0fEMcNekZlZ0mwXr/YbgccA7wA2DX85ZmZbNdvFu23AqpslLS+hHjOz5zXbxduz5uYoYAbw0lIqMjNLmu3i3UYxBiWKrt19gOckN7NSNdvF26/sQszMBmq2i9dB8Tm8/q9+WgZ8yZPWmVmZmu3ifRHoAL6Qbv9VWndaGUWZmUHzAXVoRLy65vb3Ja0qoyAzs37NTli3WdLL+m9I2h9/7ZSZlWxHLtRcKmlduj0V+OtSKjIzS5oNqL2AgyiC6W3Aa/H34plZyZrt4n00In4NvBh4A8XEdV8srSozM3ZgDCr9+6fAJRFxDf7SBDMrWbMBtUHSl4ATgO9I2m0H7mtmNijNhswJwPXAm9P34+0JfLC0qszMaP6jLr8BFtfcfhh4uKyi6pH0TWAfiule/iMi5rfy/GbWes2+i5eDv4mIxyWNBX4q6aqIeKx2B0nzKL4eiylTplRRo5kNo3YaRzozXb2+gqIl9fKBO0TE/Ijojojurq6ulhdoZsOrLVpQkmYDxwIzI+I3kpZRdPXMbARrlxZUJ/BECqcDgcOrLsjMytcuAfVdYBdJq4GPU3TzzGyEa4suXkT0AW+pug4za612aUGZ2U7IAWVm2XJAmVm2HFBmli0HlJllywFlZtlyQJlZthxQZpYtB5SZZcsBZWbZckCZWbYcUGaWLQeUmWXLAWVm2WqL6VYGa/To0VWXUFdnZ2fVJdS1ePHi7e9UkVGj8v1bumnTpqpLqEtS1SUMWb6/dTPb6TmgzCxbDigzy5YDysyy5YAys2w5oMwsWw4oM8uWA8rMsuWAMrNsOaDMLFsOKDPLlgPKzLLlgDKzbDmgzCxbDigzy5YDysyy1ZYBJWlET7RnZoXK/6NLOgX4ABDAamARcB6wK/AY8K6I+JWkHmAyMBXoBd5ZRb1m1jqVBpSk6cC5wKyI6JW0J0VQHR4RIek04Bzg7HSXGcDrIuK3DY43D5gHMGXKlNLrN7NyVd2COgb4RkT0AkTE45IOBhZKmkTRirqvZv8ljcIp3X8+MB+gu7s7yivbzFqh6jEoUbSYal0EXBwRBwPvBcbUbHu2VYWZWfWqDqibgBMk7QWQunidwIa0/dSqCjOz6lXaxYuINZLOB5ZL2gysBHqAKyVtAFYA+1VYoplVqOoxKCJiAbBgwOpr6uzX05KCzCwbVXfxzMwackCZWbYcUGaWLQeUmWXLAWVm2XJAmVm2HFBmli0HlJllywFlZtlyQJlZthxQZpYtB5SZZcsBZWbZqnw2g7JEBH19fVWXUVdEnpN9jhkzZvs7VWTLli1Vl9DQxo0bqy6hrrFjx1ZdQl2bNm1qel+3oMwsWw4oM8uWA8rMsuWAMrNsOaDMLFsOKDPLlgPKzLLlgDKzbDmgzCxbDigzy5YDysyy5YAys2w5oMwsWw4oM8uWA8rMstU2ASXpQEm3SLpD0nJJE6quyczK1TYBlZwcEQcDtwCnV12MmZWrbWbUjIh7am6OAR6rqhYza422Cah+kt4EvBmYWWfbPGAewD777NPiysxsuLVVF0/SKOBS4M8j4smB2yNifkR0R0R3V1dX6ws0s2HVVgEFTAaeioi1VRdiZuVrt4B6Aji76iLMrDXaLaA6gdOqLsLMWqOtBskj4iHg+KrrMLPWaLcWlJntRBxQZpYtB5SZZcsBZWbZckCZWbYcUGaWLQeUmWXLAWVm2XJAmVm2HFBmli0HlJllywFlZtlyQJlZthxQZpYtRUTVNZRC0qPA/cN0uAlA7zAda7jlWluudUG+teVaFwxvbftGRFNzco/YgBpOkm6NiO6q66gn19pyrQvyrS3XuqC62tzFM7NsOaDMLFsOqObMr7qAbci1tlzrgnxry7UuqKg2j0GZWbbcgjKzbDmgzCxbIzqgJE2VdGed9Z+X1C3py5KmVVHbjpJ0rqQ1klZLul3SH+dav6TvSBpfwXmPkxSSDmxi3/dLelEJNZwp6W5JVzTYPlfSxcN93rJIOlDSLZLukLRc0oSWnn8kj0FJmgp8OyIOqriUIZE0E/gsMDsi+tKLZNf0PYGWSFoETAJuioie7ey7HuiOiGG9MFLSPcBbIuK+BtvnpvO+bzvHGR0Rm4eztsFIYb8xItZJ+iTwbET8W6vOP6JbULUk7S9ppaQjJH0l/UVYKenotH2upMWSvitpraRP19z3GUnnS1olaYWkiWl9l6SrJP00/cxK63skXSZpmaR1ks4cYvmTgN6I6AOIiN6IeCgdvzud842SfiTpZ5KulDRuiOdsiqSTJf0kteq+JGm0pPWSJqQW7N2S/jO1/m6QNLakOsYBs4B3AyemdbMlfbtmn4vT7/lMYDKwVNLStO2k9Jq4U9KnBlnDJcD+wBJJH0otj5Xp3wNqdp28jdfZv0r6MTBT0ozUarlN0vWSJqX9lkn6VHrefy7piMHU24yIuCci1qWbY4DflXWuRgWM2B9gKnAncACwEjgEOBv4Stp+IPBAeuLnAusovl59DMXHZPZJ+wXw1rT8aeC8tPxV4HVpeQpwd1ruAW4BdqP4iMBjQMcQHsc44Hbg58AXgKPS+mVAdzrHD4Dd0/oPAf/cguf3lcC3+h9bqu0UYH2qaSqwCTgkbV8EnFxSLScDl6blW4A/AmZTtKD797kYmJuW1wMT0vLk9Droovi27e8Dbx9kHf2P/cXALmndscBVaXl7r7MT0nJHehxd6fYc4LKa3/tn0vKfAN9rwe/6TcDdwPiyz1X701ZffT5IXcA1wDsiYo2kfwEuguKvg6T7gVekfW+KiKcAJN0F7Av8EtgI9P8lvg14Q1o+Fpgmqf9cL5a0R1q+NooWT5+kR4CJwIODeQAR8YykGcARwNHAQkn/VLPL4cA04OZUy67AjwZzrh30emAG8NN03rHAIwP2uS8ibk/Lt1GEVhlOAj6Xlr+ebl/b5H0PBZZFxKMAafzoSOCbQ6inE1gg6eUUwdNRs63R62wzcFXa5wDgIODG9NyOBh6uOcbi9G+ZzympxlHApcDREfFkmecaaGcIqKcofvmzgDWAtrFvX83yZrY+P89F+jMyYP0oYGZE/Lb2IOkF1ehYgxLFeMQyYJmkO4BTa08J3BgRJw3lHIMgYEFEfPgFK4txln4Dn4dh7+JJ2gs4BjhIUlD8Zw5gCS8cxhjT6BDDXRPwcWBpRByXxkKX1Wxr9Nr4XWwddxKwJiJmNjh+/zGG/NpqwmTgqYhYW/J5fs/OMAa1EXg7cIqkd1J0hd4FIOkVFF2zewd57BuA5wc7JR0ytFLrk3RA+kvc7xBeOFPDCmCWpD9M+78oPbay3QQcL+kP0nn3lLRvC8470PHA5RGxb0RMjYh9gP5B6mmSdpPUSdHi6/c00N/a/TFwVBo3G03R+lo+xJo6gQ1pee4g7n8v0JXeIEFSh6TpQ6xpsJ6gGBppuZ0hoIiIZ4E/A/4B+AUwOrVCFlKMSfRt6/7bcCbQreKt/7uA04el4N83jqK7cJek1RTduZ7+jalrMhf4Wtq+gmJ8rVQRcRdwHnBDOu+NFAP6rXYScPWAdVcB76QY91oNXEExDtlvPnCdpKUR8TDwYWApsAr4WURcM8SaPg18UtLNFC26HRIRGymC91OSVlGMQb52iDUNVidwWhUnHtGXGZhZe9spWlBm1p4cUGaWLQeUmWXLAWVm2XJAmVm2HFDWEpLGSzqjBeeZLamqt+NtmDmgrFXGA00HlAqDeX3OprrrhWyY+TooawlJXwfeRnGF9FLgVcBLKD6jdl5EXJM+EnJd2j6T4hMAx1J8+PkhYC3QFxHvk9QFXELxSQCA91Ncub2C4uMfjwJ/HxE/bMXjs3I4oKwlVDM3l6RdgBdFxK9VzG21Ang5xYdm1wGvjYgVkiazdWaCpylmGViVAuqrwBci4n8kTQGuj4hXSuoBnomIC1v9GG347QwfFrb8CPiEpCOBLcDeFLM9ANwfESvS8mHA8oh4HEDSlWydeWJbM0nYCOGAsiq8i2IanBkR8ZyK2S37Zxp4tma/bc0ysK2ZJGyE8CC5tUrt7AGdwCMpnI6m6NrV8xOKWQZekrqF76jZ1mgmidrzWJtzQFlLRMRjFBPq3UkxXUy3pFspWlP3NLjPBuATFNOhfA+4i2J+L2g8k8S3gONUTEFc2lS41hoeJLesSRqXZhTdhWJKlcsiYuDUKjZCuQVlueuRdDvF3PL3MbRpeK3NuAVlZtlyC8rMsuWAMrNsOaDMLFsOKDPLlgPKzLL1/z2ONM2WZ3b9AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fbe1607cf60>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plot_matrix(attention_matrix, target, source)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "### Using Protobuf format for inference (Suggested for efficient bulk inference)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Reading the vocabulary mappings as this mode of inference accepts list of integers and returns list of integers."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import io\n",
-    "import tempfile\n",
-    "from record_pb2 import Record\n",
-    "from create_vocab_proto import vocab_from_json, reverse_vocab, write_recordio, list_to_record_bytes, read_next\n",
-    "\n",
-    "source = vocab_from_json(\"vocab.src.json\")\n",
-    "target = vocab_from_json(\"vocab.trg.json\")\n",
-    "\n",
-    "source_rev = reverse_vocab(source)\n",
-    "target_rev = reverse_vocab(target)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sentences = [\"this is so cool\",\n",
-    "            \"i am having dinner .\",\n",
-    "            \"i am sitting in an aeroplane .\",\n",
-    "            \"come let us go for a long drive .\"]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Converting the string to integers, followed by protobuf encoding:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Convert strings to integers using source vocab mapping. Out-of-vocabulary strings are mapped to 1 - the mapping for <unk>\n",
-    "sentences = [[source.get(token, 1) for token in sentence.split()] for sentence in sentences]\n",
-    "f = io.BytesIO()\n",
-    "for sentence in sentences:\n",
-    "    record = list_to_record_bytes(sentence, [])\n",
-    "    write_recordio(f, record)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = runtime.invoke_endpoint(EndpointName=endpoint_name, \n",
-    "                                   ContentType='application/x-recordio-protobuf', \n",
-    "                                   Body=f.getvalue())\n",
-    "\n",
-    "response = response[\"Body\"].read()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now, parse the protobuf response and convert list of integers back to strings"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def _parse_proto_response(received_bytes):\n",
-    "    output_file = tempfile.NamedTemporaryFile()\n",
-    "    output_file.write(received_bytes)\n",
-    "    output_file.flush()\n",
-    "    target_sentences = []\n",
-    "    with open(output_file.name, 'rb') as datum:\n",
-    "        next_record = True\n",
-    "        while next_record:\n",
-    "            next_record = read_next(datum)\n",
-    "            if next_record:\n",
-    "                rec = Record()\n",
-    "                rec.ParseFromString(next_record)\n",
-    "                target = list(rec.features[\"target\"].int32_tensor.values)\n",
-    "                target_sentences.append(target)\n",
-    "            else:\n",
-    "                break\n",
-    "    return target_sentences"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "targets = _parse_proto_response(response)\n",
-    "resp = [\" \".join([target_rev.get(token, \"<unk>\") for token in sentence]) for\n",
-    "                               sentence in targets]\n",
-    "print(resp)"
    ]
   },
   {

--- a/SageMaker-Seq2Seq-Translation-English-German-InternetFacingApp.ipynb
+++ b/SageMaker-Seq2Seq-Translation-English-German-InternetFacingApp.ipynb
@@ -46,8 +46,8 @@
    "outputs": [],
    "source": [
     "# S3 bucket and prefix\n",
-    "bucket = 'sagemaker-robpercaws-lab'\n",
-    "prefix = 'sagemaker/seq2seq/eng-german'  # E.g.'sagemaker/seq2seq/eng-german'"
+    "bucket = '<your_s3_bucket_name_here>'\n",
+    "prefix = 'sagemaker/<your_s3_prefix_here>'  # E.g.'sagemaker/seq2seq/eng-german'"
    ]
   },
   {


### PR DESCRIPTION
protobuf cells were missing dependencies from main seq2seq examples so they would not work. These cells do not contribute to the main objective of the lab so it might be best to just remove them.